### PR TITLE
Bump version to python 3.9

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -11,20 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
-
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-
-
     - name: Run scraper
       run: python Scraper.py
-    
     - name: Run poster
       run: python Poster.py --dry-run
       env:


### PR DESCRIPTION
Closes #8

Will need to add python 3.10 support in the future after `dicttoxml` is updated or all dependencies migrated to `dicttoxml2`
﻿
