### PR TITLE
Support for python 3.10

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -9,12 +9,16 @@ on:
 jobs:
   smoke-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10']
+
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.9
+        language_version: python3.10
   - repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,15 @@ maintainers = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9"
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10"
 ]
 requires-python = ">=3.8"
 
 dependencies = [
     "requests",
     "pandas",
-    "dicttoxml",
+    "dicttoxml>=1.7.8,<2.0.0",
     "ostiapi @ git+https://github.com/doecode/ostiapi.git",
     "pydantic[dotenv]<2.0.0",
     "rich",
@@ -51,4 +52,4 @@ version = {attr = "pdc_osti.__version__"}
 
 [tool.black]
 line-length = 88
-target-version = ["py39"]
+target-version = ["py310"]

--- a/src/pdc_osti/poster.py
+++ b/src/pdc_osti/poster.py
@@ -176,7 +176,10 @@ class Poster:
         try:
             ostiapi.datatoxml(records)  # Check that JSON can be parsed into XML
         except AttributeError:
-            raise AttributeError("Failure to load data into XML!")
+            raise AttributeError(
+                "Failure to load data into XML!\n"
+                "Check your dicttoxml version (requires > 1.7.4)"
+            )
         else:
             self.log.info("[bold green]Data loaded into XML!")
 

--- a/src/pdc_osti/poster.py
+++ b/src/pdc_osti/poster.py
@@ -173,6 +173,11 @@ class Poster:
     def _fake_post(self, records):
         """A fake JSON response that mirrors OSTI's"""
         self.log.info("[bold yellow]Fake posting")
+        try:
+            ostiapi.datatoxml(records)  # Check that JSON can be parsed into XML
+        except AttributeError:
+            raise AttributeError("Failure to load data into XML")
+
         return {
             "record": [
                 {

--- a/src/pdc_osti/poster.py
+++ b/src/pdc_osti/poster.py
@@ -176,7 +176,9 @@ class Poster:
         try:
             ostiapi.datatoxml(records)  # Check that JSON can be parsed into XML
         except AttributeError:
-            raise AttributeError("Failure to load data into XML")
+            raise AttributeError("Failure to load data into XML!")
+        else:
+            self.log.info("[bold green]Data loaded into XML!")
 
         return {
             "record": [


### PR DESCRIPTION
Closes #28

This PR ensure that `pdc-osti` will run with python 3.10 using an updated `dicttoxml` library.
