### PR TITLE
Fix OpenSSL issue on GitHub Actions

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -23,6 +23,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .
+    - name: OpenSSL version
+      run: openssl version
     - name: Run scraper
       run: scraper
     - name: Run poster

--- a/src/pdc_osti/scraper.py
+++ b/src/pdc_osti/scraper.py
@@ -193,7 +193,7 @@ class Scraper:
 
         def get_handle(doi, redirects_j):
             if doi not in redirects_j:
-                r = requests.get(doi)
+                r = get_legacy_session().get(doi)
                 assert r.status_code == 200, f"Error parsing DOI: {doi}"
                 handle = r.url.split("handle/")[-1]
                 redirects_j[doi] = handle

--- a/src/pdc_osti/scraper.py
+++ b/src/pdc_osti/scraper.py
@@ -57,6 +57,7 @@ REPLACE_DICT = {
 }
 
 
+# Fix for OpenSSL issue: https://github.com/pulibrary/pdc-osti/issues/31
 class CustomHttpAdapter(requests.adapters.HTTPAdapter):
     # "Transport adapter" that allows us to use custom ssl_context.
 
@@ -134,7 +135,7 @@ class Scraper:
                 "https://www.osti.gov/dataexplorer/api/v1/records?"
                 f"site_ownership_code=PPPL&page={page}"
             )
-            r = get_legacy_session().get(url)
+            r = get_legacy_session().get(url)  # fix for #31
             j = json.loads(r.text)
             if len(j) != 0:
                 existing_datasets.extend(j)
@@ -193,7 +194,7 @@ class Scraper:
 
         def get_handle(doi, redirects_j):
             if doi not in redirects_j:
-                r = get_legacy_session().get(doi)
+                r = get_legacy_session().get(doi)  # fix for #31
                 assert r.status_code == 200, f"Error parsing DOI: {doi}"
                 handle = r.url.split("handle/")[-1]
                 redirects_j[doi] = handle
@@ -414,6 +415,7 @@ def get_doe_funding(grant_nos: str) -> Dict[str, set]:
     return grant_dict
 
 
+# Fix for OpenSSL issue: https://github.com/pulibrary/pdc-osti/issues/31
 def get_legacy_session():
     ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
     ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT


### PR DESCRIPTION
Closes #31 

Recently GitHub Actions updated their `openssl` version to support `3.x`. However, a number of servers (DOE Data Explorer, and DOI redirect / DataSpace) do not support 3.x, causing `requests` to fail.

This quick solution was what I adopted from: https://stackoverflow.com/a/73519818/15080854

Improvements would be needed, but with limited time to develop, this was the best I could come up with.
