### PR TITLE
Populate DOI for OSTI submissions if available

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -26,9 +26,13 @@ jobs:
     - name: OpenSSL version
       run: openssl version
     - name: Run scraper
-      run: scraper -s dspace
+      run: |
+        scraper -s dspace
+        scraper -s pdc
     - name: Run poster
-      run: poster -s dspace -m dry-run
+      run: |
+        poster -s dspace -m dry-run
+        poster -s pdc -m dry-run
       env:
         OSTI_USERNAME_TEST: my-test-osti-username
         OSTI_PASSWORD_TEST: my-test-osti-password

--- a/src/pdc_osti/__init__.py
+++ b/src/pdc_osti/__init__.py
@@ -6,6 +6,4 @@ DATASPACE_URI = "https://dataspace.princeton.edu"
 DSPACE_ID = "DSpace ID"
 
 PDC_QUERY = {"per_page": 20}
-PDC_URI = (
-    "https://pdc-discovery-staging.princeton.edu/discovery/pppl_reporting_feed.json"
-)
+PDC_URI = "https://pdc-discovery-prod.princeton.edu/discovery/pppl_reporting_feed.json"

--- a/src/pdc_osti/commons.py
+++ b/src/pdc_osti/commons.py
@@ -35,14 +35,17 @@ def get_description(item: dict, princeton_source: str) -> str:
 def get_is_referenced_by(item: dict, princeton_source: str) -> str:
     """Retrieve IsReferencedBy for dataset"""
     if princeton_source == "dspace":
-        isreferencedby = get_dc_value(item, "dc.relation.isreferencedby")
+        isreferencedby = [
+            val.split("doi.org/")[1]
+            for val in get_dc_value(item, "dc.relation.isreferencedby")
+        ]
     elif princeton_source == "pdc":
         related_objects = item["resource"].get("related_objects")
         if related_objects:
             isreferencedby = [
                 m["related_identifier"]
                 for m in related_objects
-                if m["relation_type"] == "IsCitedBy"
+                if m["relation_type"] in ["IsCitedBy", "IsReferencedBy"]
             ]
         else:
             isreferencedby = []

--- a/src/pdc_osti/poster.py
+++ b/src/pdc_osti/poster.py
@@ -142,12 +142,14 @@ class Poster:
 
             # Add existing DOI if it exists
             if self.princeton_source == "pdc":
-                doi = princeton_data.get("doi")
+                doi = row["DOI"]
                 if doi:
                     if not doi.startswith("10.11578"):
                         item_dict["doi"] = doi
                     else:
                         self.log.debug(f"OSTI DOI minted: {doi}")
+                else:
+                    self.log.warning("[bold red] No DOI!!!")
 
             # Collect optional required information
             is_referenced_by = get_is_referenced_by(

--- a/src/pdc_osti/poster.py
+++ b/src/pdc_osti/poster.py
@@ -140,6 +140,15 @@ class Poster:
                 "keywords": get_keywords(princeton_data, self.princeton_source),
             }
 
+            # Add existing DOI if it exists
+            if self.princeton_source == "pdc":
+                doi = princeton_data.get("doi")
+                if doi:
+                    if not doi.startswith("10.11578"):
+                        item_dict["doi"] = doi
+                    else:
+                        self.log.debug(f"OSTI DOI minted: {doi}")
+
             # Collect optional required information
             is_referenced_by = get_is_referenced_by(
                 princeton_data, self.princeton_source

--- a/src/pdc_osti/poster.py
+++ b/src/pdc_osti/poster.py
@@ -125,6 +125,7 @@ class Poster:
             princeton_data = princeton_data[0]
 
             # Collect all required information
+            # site_url and accession_num are initial settings
             item_dict = {
                 "title": row["Title"],
                 "creators": row["Author"],
@@ -146,10 +147,13 @@ class Poster:
                 if doi:
                     if not doi.startswith("10.11578"):
                         item_dict["doi"] = doi
+                        # Uses DOI moving forward
+                        item_dict["accession_num"] = doi
+                        item_dict["site_url"] = f"https://doi.org/{doi}"
                     else:
                         self.log.debug(f"OSTI DOI minted: {doi}")
                 else:
-                    self.log.warning("[bold red] No DOI!!!")
+                    self.log.warning("[bold red]No DOI!!!")
 
             # Collect optional required information
             is_referenced_by = get_is_referenced_by(

--- a/src/pdc_osti/poster.py
+++ b/src/pdc_osti/poster.py
@@ -160,12 +160,11 @@ class Poster:
                 for irb in is_referenced_by:
                     item_dict["related_identifiers"].append(
                         {
-                            "related_identifier": irb.split("doi.org/")[1],
+                            "related_identifier": irb,
                             "relation_type": "IsReferencedBy",
                             "related_identifier_type": "DOI",
                         }
                     )
-
             osti_format.append(item_dict)
 
         state = "Updating" if self.osti_upload.exists() else "Writing"
@@ -198,7 +197,9 @@ class Poster:
                     "contract_nos": record["contract_nos"],
                     "other_identifying_nos": None,
                     "othnondoe_contract_nos": record["othnondoe_contract_nos"],
-                    "doi": "10.11578/1488485",
+                    "doi": record.get("doi")
+                    if record.get("doi")
+                    else "10.11578/1488485",
                     "doi_status": "PENDING",
                     "status": "SUCCESS",
                     "status_message": None,

--- a/src/pdc_osti/scraper.py
+++ b/src/pdc_osti/scraper.py
@@ -317,6 +317,7 @@ class Scraper:
                 f"{datetime.fromisoformat(item['group']['created_at']):%Y-%m-%d}"
                 for item in to_upload_j
             ]
+            df["DOI"] = [item["resource"].get("doi") for item in to_upload_j]
             df["Title"] = [
                 item["resource"]["titles"][0]["title"] for item in to_upload_j
             ]

--- a/src/pdc_osti/scraper.py
+++ b/src/pdc_osti/scraper.py
@@ -2,7 +2,6 @@ import argparse
 import json
 import re
 import ssl
-from datetime import datetime
 from logging import Logger
 from pathlib import Path
 from typing import Dict, List
@@ -314,8 +313,7 @@ class Scraper:
             ]
         elif self.princeton_source == "pdc":
             df["Issue Date"] = [
-                f"{datetime.fromisoformat(item['group']['created_at']):%Y-%m-%d}"
-                for item in to_upload_j
+                f"{item['resource']['publication_year']}" for item in to_upload_j
             ]
             df["DOI"] = [item["resource"].get("doi") for item in to_upload_j]
             df["Title"] = [


### PR DESCRIPTION
Closes #40
Closes #49
Closes #50 

This PR is intended to ensure that DOI that are minted through Princeton or something else (not OSTI) is included in the metadata to OSTI when submission is occurred.

This should be:
- [x] Tested on ELink test with DOI from PRDS
- [x] Test with a mixed case where only ARK is available (This isn't applicable now since we will mint DOIs always)
